### PR TITLE
✨ Add MonthlyStatistics tracking and enriched view for product removals

### DIFF
--- a/backend/App.BLL.Contracts/IMonthlyStatisticsService.cs
+++ b/backend/App.BLL.Contracts/IMonthlyStatisticsService.cs
@@ -5,4 +5,5 @@ namespace App.BLL.Contracts;
 public interface IMonthlyStatisticsService : IBaseService<DTO.MonthlyStatistics>
 {
     Task<IEnumerable<DTO.MonthlyStatistics?>> GetByStorageRoomIdAsync(Guid storageRoomId);
+    Task<IEnumerable<DTO.MonthlyStatistics?>> GetEnrichedMonthlyStatistics();
 }

--- a/backend/App.BLL/AppBll.cs
+++ b/backend/App.BLL/AppBll.cs
@@ -15,7 +15,7 @@ public class AppBll: BaseBll<IAppUOW>, IAppBLL
 
     private IActionEntityService? _actionEntityService;
     public IActionEntityService ActionEntityService => 
-        _actionEntityService ??= new ActionEntityService(BLLUOW, new ActionEntityBLLMapper(), new CurrentStockUOWMapper(), new ActionEntityUOWMapper());
+        _actionEntityService ??= new ActionEntityService(BLLUOW, new ActionEntityBLLMapper(), new MonthlyStatisticsUOWMapper(), new ActionEntityUOWMapper());
     
     private IActionTypeEntityService? _actionTypeEntityService;
     public  IActionTypeEntityService ActionTypeEntityService => 

--- a/backend/App.BLL/Services/MonthlyStatisticsService.cs
+++ b/backend/App.BLL/Services/MonthlyStatisticsService.cs
@@ -22,4 +22,10 @@ public class MonthlyStatisticsService : BaseService<MonthlyStatistics, DAL.DTO.M
         var res = await ServiceRepository.GetByStorageRoomIdAsync(storageRoomId);
         return res.Select(u => _dalToBLLMapper.Map(u));
     }
+    
+    public async Task<IEnumerable<MonthlyStatistics?>> GetEnrichedMonthlyStatistics()
+    {
+        var res = await ServiceRepository.GetEnrichedMonthlyStatistics();
+        return res.Select(u => _dalToBLLMapper.Map(u));
+    }
 }

--- a/backend/App.DAL.Contracts/IMonthlyStatisticsRepository.cs
+++ b/backend/App.DAL.Contracts/IMonthlyStatisticsRepository.cs
@@ -6,4 +6,6 @@ namespace App.DAL.Contracts;
 public interface IMonthlyStatisticsRepository: IBaseRepository<MonthlyStatistics>
 {
     Task<IEnumerable<MonthlyStatistics?>> GetByStorageRoomIdAsync(Guid storageRoomId);
+    Task<Domain.Logic.MonthlyStatistics?> FindByProductAndStorageAsync(Guid productId, Guid storageRoomId);
+    Task<IEnumerable<MonthlyStatistics?>> GetEnrichedMonthlyStatistics();
 }

--- a/backend/App.DAL.EF/Repositories/MonthlyStatisticsRepository.cs
+++ b/backend/App.DAL.EF/Repositories/MonthlyStatisticsRepository.cs
@@ -21,4 +21,20 @@ public class MonthlyStatisticsRepository: BaseRepository<MonthlyStatistics, Doma
 
         return domainEntities.Select(e => Mapper.Map(e));
     }
+    
+    public async Task<Domain.Logic.MonthlyStatistics?> FindByProductAndStorageAsync(Guid productId, Guid storageRoomId)
+    {
+        return await RepositoryDbSet
+            .FirstOrDefaultAsync(c => c.ProductId == productId && c.StorageRoomId == storageRoomId);
+    }
+    
+    public async Task<IEnumerable<MonthlyStatistics?>> GetEnrichedMonthlyStatistics()
+    {
+        var domainEntities = await RepositoryDbSet
+            .Include(a => a.Product)
+            .Include(a => a.StorageRoom)
+            .ToListAsync();
+
+        return domainEntities.Select(e => Mapper.Map(e));
+    }
 }

--- a/backend/App.DTO/v1/ApiEntities/EnrichedMonthlyStatistics.cs
+++ b/backend/App.DTO/v1/ApiEntities/EnrichedMonthlyStatistics.cs
@@ -1,0 +1,25 @@
+using Base.Contracts;
+
+namespace App.DTO.v1.ApiEntities;
+
+public class EnrichedMonthlyStatistics : IDomainId
+{
+    public Guid Id { get; set; }
+    
+    public Guid ProductId { get; set; }
+    public string ProductName { get; set; } = default!;
+    public string ProductCode { get; set; } = default!;
+    public string ProductUnit { get; set; } = default!;
+    
+    public Guid StorageRoomId { get; set; }
+    public string StorageRoomName { get; set; } = default!;
+    
+    public decimal TotalRemovedQuantity { get; set; }
+    public int Year { get; set; }
+    public int Month { get; set; }
+    public DateTime PeriodStart => new DateTime(Year, Month, 1);
+    
+    
+    
+
+}

--- a/backend/App.DTO/v1/ApiMapper/EnrichedMonthlyStatisticsAPIMapper.cs
+++ b/backend/App.DTO/v1/ApiMapper/EnrichedMonthlyStatisticsAPIMapper.cs
@@ -1,0 +1,35 @@
+using App.DTO.v1.ApiEntities;
+using Base.Contracts;
+
+namespace App.DTO.v1.ApiMapper;
+
+public class EnrichedMonthlyStatisticsAPIMapper : IMapper<EnrichedMonthlyStatistics, BLL.DTO.MonthlyStatistics>
+{
+    public EnrichedMonthlyStatistics? Map(BLL.DTO.MonthlyStatistics? entity)
+    {
+        if (entity == null) return null;
+
+        return new EnrichedMonthlyStatistics
+        {
+            Id = entity.Id,
+            
+            ProductId = entity.ProductId,
+            ProductCode = entity.Product?.Code ?? "Unknown",
+            ProductName = entity.Product?.Name ?? "Unknown",
+            ProductUnit = entity.Product?.Unit ?? "Unknown",
+            
+            StorageRoomId = entity.StorageRoomId,
+            StorageRoomName = entity.StorageRoom?.Name ?? "Unknown",
+            
+            TotalRemovedQuantity = entity.TotalRemovedQuantity,
+            Year = entity.Year,
+            Month = entity.Month,
+        };
+    }
+
+    public BLL.DTO.MonthlyStatistics? Map(EnrichedMonthlyStatistics? entity)
+    {
+        throw new NotImplementedException("Mapping from API to BLL is not required.");
+    }
+    
+}

--- a/backend/WebApp/ApiControllers/MonthlyStatisticsController.cs
+++ b/backend/WebApp/ApiControllers/MonthlyStatisticsController.cs
@@ -1,5 +1,7 @@
 using App.BLL.Contracts;
 using App.DTO.v1;
+using App.DTO.v1.ApiEntities;
+using App.DTO.v1.ApiMapper;
 using App.DTO.v1.Mappers;
 using Asp.Versioning;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
@@ -19,6 +21,8 @@ namespace WebApp.ApiControllers
         private readonly IAppBLL _bll;
         
         private readonly MonthlyStatisticsAPIMapper _mapper = new();
+        
+        private readonly EnrichedMonthlyStatisticsAPIMapper _enrichedMonthlyStatisticsAPIMapper = new();
 
         public MonthlyStatisticsController(IAppBLL bll, ILogger<MonthlyStatisticsController> logger)
         {
@@ -110,13 +114,22 @@ namespace WebApp.ApiControllers
         }
         
         [HttpGet("bystorageroom/{id}")]
-        [ProducesResponseType(typeof(IEnumerable<MonthlyStatistics>), StatusCodes.Status200OK)]
-        public async Task<ActionResult<IEnumerable<MonthlyStatistics>>> GetByStorageRoom(Guid id)
+        [ProducesResponseType(typeof(IEnumerable<EnrichedMonthlyStatistics>), StatusCodes.Status200OK)]
+        public async Task<ActionResult<IEnumerable<EnrichedMonthlyStatistics>>> GetByStorageRoom(Guid id)
         {
             var stocks = await _bll.MonthlyStatisticsService.GetByStorageRoomIdAsync(id);
             var res = stocks.Select(x => _mapper.Map(x)!);
             return Ok(res);
-            
+        }
+        
+        [HttpGet("enrichedMonthlyStatistics/")]
+        [ProducesResponseType(typeof(IEnumerable<EnrichedMonthlyStatistics>), StatusCodes.Status200OK)]
+        public async Task<ActionResult<IEnumerable<EnrichedMonthlyStatistics>>> GetEnrichedMonthlyStatistics()
+        {
+            var data = await _bll.MonthlyStatisticsService.GetEnrichedMonthlyStatistics();
+
+            var res = data.Select(u => _enrichedMonthlyStatisticsAPIMapper.Map(u)!).ToList();
+            return Ok(res);
         }
     }
 }

--- a/frontend/src/domain/logic/IMonthlyStatistics.ts
+++ b/frontend/src/domain/logic/IMonthlyStatistics.ts
@@ -1,0 +1,9 @@
+import type {IDomainId} from "@/domain/IDomainId.ts";
+
+export interface IMonthlyStatistics extends IDomainId {
+  productId: string;
+  storageRoomId: string;
+  totalRemovedQuantity: number;
+  year: number;
+  month: number;
+}

--- a/frontend/src/domain/logic/IMonthlyStatisticsEnriched.ts
+++ b/frontend/src/domain/logic/IMonthlyStatisticsEnriched.ts
@@ -1,0 +1,13 @@
+import type {IDomainId} from "@/domain/IDomainId.ts";
+
+export interface IMonthlyStatisticsEnriched extends IDomainId {
+  productId: string;
+  productName: string;
+  productCode: string;
+  productUnit: string;
+  storageRoomId: string;
+  storageRoomName: string;
+  totalRemovedQuantity: number;
+  year: number;
+  month: number;
+}

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -24,6 +24,7 @@ import CreateRolePage from "@/views/AccountView/CreateRolePage.vue";
 import UserListWithRoles from "@/views/AccountView/UserListWithRoles.vue";
 import Home from "@/views/Home.vue";
 import {User} from "lucide-vue-next";
+import MonthlyStatistics from "@/views/InventoryView/MonthlyStatistics.vue";
 
 const routes = [
   { path: "/home", name: "Home", component: Home },
@@ -41,6 +42,7 @@ const routes = [
   { path: "/editsupplier/:id", name: "EditSupplier", component: EditSupplier },
   { path: "/storagerooms", name: "StorageRooms", component: StorageRooms },
   { path: "/currentstock/:storageRoomId", name: "CurrentStock", component: CurrentStock },
+  { path: "/monthlyStatistics/:storageRoomId", name: "MonthlyStatistics", component: MonthlyStatistics },
   { path: "/editcurrentstock/:id", name: "EditCurrentStock", component: EditCurrentstock },
   { path: "/createcurrentStock", name: "CreateCurrentStock", component: CreateCurrentStock },
   { path: "/users/:id", name: "UserDetails", component: UserDetailsView },
@@ -71,6 +73,7 @@ router.beforeEach((to, from, next) => {
     "/editsupplier/:id",
     "/storagerooms",
     "/currentstock/:storageRoomId",
+    "/monthlyStatistics/:storageRoomId",
     "/editcurrentstock/:id",
     "/createcurrentStock",
     "/users/:id",

--- a/frontend/src/services/mvcServices/MonthlyStatisticsService.ts
+++ b/frontend/src/services/mvcServices/MonthlyStatisticsService.ts
@@ -1,0 +1,26 @@
+import {BaseEntityService} from "@/services/BaseEntityService.ts";
+import type {ICurrentStock} from "@/domain/logic/ICurrentStock.ts";
+import type {IResultObject} from "@/types/IResultObject.ts";
+import type {ICurrentStockEnriched} from "@/domain/logic/ICurrentStockEnriched.ts";
+import type {IMonthlyStatistics} from "@/domain/logic/IMonthlyStatistics.ts";
+import type {IActionEnriched} from "@/domain/logic/IActionEnriched.ts";
+import type {IMonthlyStatisticsEnriched} from "@/domain/logic/IMonthlyStatisticsEnriched.ts";
+
+export class MonthlyStatisticsService extends BaseEntityService<IMonthlyStatistics> {
+  constructor() {
+    super('monthlyStatistics');
+  }
+
+  async getByStorageRoomId(id: string): Promise<IResultObject<IMonthlyStatisticsEnriched[]>> {
+    const response = await this.axiosInstance.get(`/monthlyStatistics/bystorageroom/${id}`);
+    return { data: response.data };
+  }
+
+  async getEnrichedMonthlyStatistics(): Promise<IResultObject<IMonthlyStatisticsEnriched[]>> {
+    const response = await this.axiosInstance.get('/monthlyStatistics/enrichedMonthlyStatistics');
+    return {
+      data: response.data as IMonthlyStatisticsEnriched[],
+      errors: [],
+    };
+  }
+}

--- a/frontend/src/views/InventoryView/MonthlyStatistics.vue
+++ b/frontend/src/views/InventoryView/MonthlyStatistics.vue
@@ -1,0 +1,369 @@
+<script setup lang="ts">
+import { ref, onMounted, computed } from "vue";
+import { useRoute } from "vue-router";
+import { MonthlyStatisticsService } from "@/services/mvcServices/MonthlyStatisticsService";
+import type { IMonthlyStatistics } from "@/domain/logic/IMonthlyStatistics";
+import type {IMonthlyStatisticsEnriched} from "@/domain/logic/IMonthlyStatisticsEnriched.ts";
+
+const route = useRoute();
+const storageRoomId = route.params.storageRoomId as string;
+
+const service = new MonthlyStatisticsService();
+const data = ref<IMonthlyStatisticsEnriched[]>([]);
+
+const selectedYear = ref(new Date().getFullYear());
+const selectedMonth = ref(new Date().getMonth() + 1);
+
+const yearOptions = Array.from({ length: 5 }, (_, i) => new Date().getFullYear() - i);
+const monthOptions = Array.from({ length: 12 }, (_, i) => i + 1);
+
+const filteredData = computed(() =>
+  data.value.filter(
+    (x) => x.year === selectedYear.value && x.month === selectedMonth.value
+  )
+);
+
+onMounted(async () => {
+  const result = await service.getEnrichedMonthlyStatistics();
+  data.value = (result.data || []).filter(item => item.storageRoomId === storageRoomId);
+});
+</script>
+
+<template>
+  <main class="product-wrapper">
+    <section class="product-header">
+      <div class="product-header-left">
+        <h1 class="page-title">📊 Monthly Statistics</h1>
+        <p class="subtitle">Removed product quantities per month</p>
+      </div>
+    </section>
+
+    <div class="filter-bar">
+      <div class="filter-controls">
+        <select v-model="selectedYear" class="search-box">
+          <option v-for="year in yearOptions" :key="year" :value="year">{{ year }}</option>
+        </select>
+        <select v-model="selectedMonth" class="search-box">
+          <option v-for="month in monthOptions" :key="month" :value="month">{{ month }}</option>
+        </select>
+      </div>
+    </div>
+
+    <div class="table-scroll-container">
+      <table class="table table-striped table-bordered">
+        <thead>
+        <tr>
+          <th>Product</th>
+          <th>Product Code</th>
+          <th>Product Unit</th>
+          <th>Removed Quantity</th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr v-for="item in filteredData" :key="item.id">
+          <td>{{ item.productName }}</td>
+          <td>{{ item.productCode }}</td>
+          <td>{{ item.productUnit }}</td>
+          <td>{{ item.totalRemovedQuantity }}</td>
+        </tr>
+        </tbody>
+      </table>
+    </div>
+  </main>
+</template>
+
+<style scoped>
+.product-wrapper {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  padding: 2rem;
+  box-sizing: border-box;
+  max-width: 1600px;
+  margin: 0 auto;
+  font-family: 'Inter', 'Segoe UI', sans-serif;
+  color: white;
+  background: transparent;
+}
+
+.product-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+  flex-wrap: wrap;
+}
+
+.product-header-left {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.page-title {
+  font-size: 2.6rem;
+  font-weight: 800;
+  color: #ffaa33;
+  text-shadow: 0 0 10px rgba(255, 170, 51, 0.25);
+  margin: 0;
+}
+
+.subtitle {
+  font-size: 1rem;
+  color: #bbb;
+  margin: 0;
+  opacity: 0.85;
+}
+
+.filter-bar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 1rem;
+  background: rgba(30, 30, 30, 0.6);
+  backdrop-filter: blur(8px);
+  padding: 1rem 1.5rem;
+  border-radius: 16px;
+  box-shadow: 0 0 12px rgba(255, 170, 51, 0.05);
+}
+
+.filter-controls {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.search-box {
+  padding: 0.6rem 1rem;
+  font-size: 1rem;
+  border-radius: 12px;
+  border: 1px solid #ffaa33;
+  background-color: rgba(43, 43, 43, 0.5);
+  color: white;
+  min-width: 220px;
+  transition: all 0.2s ease;
+}
+
+.search-box:focus {
+  outline: none;
+  border-color: #ffc266;
+  background-color: rgb(43, 43, 43);
+}
+
+.search-box::placeholder {
+  color: #ccc;
+}
+
+.create-link {
+  background: linear-gradient(to right, #ffaa33, #ff8c00);
+  color: black;
+  padding: 0.6rem 1.4rem;
+  border-radius: 12px;
+  font-weight: 700;
+  text-decoration: none;
+  box-shadow: 0 2px 6px rgba(255, 165, 0, 0.2);
+  transition: all 0.2s ease;
+}
+
+.create-link:hover {
+  background: linear-gradient(to right, #ffc56e, #ffa726);
+  box-shadow: 0 3px 10px rgba(255, 165, 0, 0.3);
+}
+
+.table-scroll-container {
+  flex-grow: 1;
+  overflow-y: auto;
+  padding: 1.2rem;
+  margin-top: 1rem;
+  border-radius: 16px;
+  background: rgba(20, 20, 20, 0.5);
+  backdrop-filter: blur(6px);
+  box-shadow: inset 0 0 20px rgba(255, 165, 0, 0.05);
+}
+
+.product-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 1.5rem;
+}
+
+.product-card {
+  background: rgba(45, 45, 45, 0.6);
+  border-radius: 14px;
+  padding: 1rem;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  transition: all 0.3s ease;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+}
+
+.product-card:hover {
+  box-shadow: 0 6px 16px rgba(255, 170, 51, 0.1);
+  transform: translateY(-3px);
+  border-color: #ffaa33;
+}
+
+.product-info h3 {
+  color: #ffaa33;
+  font-size: 1.1rem;
+  margin-bottom: 0.4rem;
+}
+
+.product-info p {
+  color: #ccc;
+  font-size: 0.95rem;
+  margin: 0.1rem 0;
+}
+
+.view-button {
+  margin-top: 1rem;
+  padding: 0.4rem 1rem;
+  border: none;
+  border-radius: 8px;
+  background: linear-gradient(to right, #ffaa33, #ff8c00);
+  color: black;
+  font-weight: bold;
+  font-size: 0.9rem;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.view-button:hover {
+  background-color: #ffc266;
+}
+
+.button-group {
+  display: flex;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+}
+
+@media (max-width: 768px) {
+  .product-header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 1rem;
+  }
+
+  .filter-bar {
+    flex-direction: column;
+  }
+
+  .product-list {
+    grid-template-columns: 1fr;
+  }
+}
+
+.drawer-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  justify-content: flex-end;
+  z-index: 999;
+}
+
+.drawer {
+  width: 420px;
+  background: linear-gradient(to bottom, #1e1e1e, #121212);
+  color: white;
+  padding: 2rem;
+  overflow-y: auto;
+  height: 100%;
+  box-shadow: -8px 0 20px rgba(0, 0, 0, 0.5);
+  display: flex;
+  flex-direction: column;
+  gap: 1.2rem;
+  border-left: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.drawer input {
+  width: 100%;
+  padding: 0.6rem 1rem;
+  border-radius: 10px;
+  border: none;
+  background: rgba(60, 60, 60, 0.7);
+  color: white;
+  font-size: 1rem;
+  transition: all 0.2s;
+}
+
+.drawer input:focus {
+  outline: none;
+  background: rgba(80, 80, 80, 0.85);
+  border: 1px solid #ffaa33;
+}
+
+.drawer-buttons {
+  display: flex;
+  justify-content: flex-end;
+  gap: 1rem;
+  margin-top: 1.5rem;
+}
+
+.update-btn {
+  background: linear-gradient(to right, #ffaa33, #ff8c00);
+  color: black;
+  font-size: 0.95rem;
+  padding: 0.6rem 1.4rem;
+  border-radius: 10px;
+  font-weight: 700;
+  border: none;
+  cursor: pointer;
+  box-shadow: 0 3px 8px rgba(0, 0, 0, 0.2);
+}
+
+.cancel-btn {
+  background: #333;
+  color: white;
+  font-size: 0.95rem;
+  padding: 0.6rem 1.4rem;
+  border-radius: 10px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.cancel-btn:hover {
+  background: #444;
+}
+
+.text-danger {
+  color: #ff4d4d;
+  font-weight: bold;
+  text-align: center;
+}
+
+.text-success {
+  color: #28a745;
+  font-weight: bold;
+  text-align: center;
+}
+
+a.view-button {
+  text-decoration: none;
+}
+
+.drawer select {
+  width: 100%;
+  padding: 0.6rem 1rem;
+  border-radius: 10px;
+  border: none;
+  background: rgba(60, 60, 60, 0.7);
+  color: white;
+  font-size: 1rem;
+  appearance: none;
+  background-image: url('data:image/svg+xml;charset=US-ASCII,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 4 5"><path fill="white" d="M2 0L0 2h4zm0 5L0 3h4z"/></svg>');
+  background-repeat: no-repeat;
+  background-position: right 0.75rem center;
+  background-size: 0.65rem auto;
+  transition: all 0.2s;
+}
+
+.drawer select:focus {
+  outline: none;
+  background: rgba(80, 80, 80, 0.85);
+  border: 1px solid #ffaa33;
+}
+</style>

--- a/frontend/src/views/InventoryView/StorageRooms.vue
+++ b/frontend/src/views/InventoryView/StorageRooms.vue
@@ -22,7 +22,7 @@ const fetchPageData = async () => {
 onMounted(fetchPageData);
 
 const goToCurrentStock = (storageRoomId: string) => {
-  router.push(`/currentstock/${storageRoomId}`);
+  router.push(`/monthlyStatistics/${storageRoomId}`);
 };
 
 const filteredStorageRooms= computed(() =>


### PR DESCRIPTION
-Implemented full backend and frontend logic for tracking product removal quantities per month -Created MonthlyStatistics domain with year/month filtering and linkage to StorageRoom and Product -Added enriched DTO (MonthlyStatisticsEnriched) containing product name, code, unit, and storage room name -Built Vue view with Excel-style table that:
-Displays removed quantities per product
-Filters by year and month
-Works per storage room
🧪 Bugs to test:

✅ Ensure that quantities from different months show in correct views ✅ Verify that quantities don't stack across months (e.g. January vs February) 🛠️ Next step:

Add logic to deduct recipe components instead of the product itself if a product has a recipe defined ✅ Tested:

View loads and filters correctly by year/month
Data matches backend updates on removal

⚠️ Requires manual DB reset:
- Remove old migrations
- Drop and recreate database
- Generate new migration
- Run database update

→ See backend/Commands.md for exact steps