### PR TITLE
feat: connect products to suppliers + add unit conversion to monthly …

### DIFF
--- a/backend/App.BLL.Contracts/IProductService.cs
+++ b/backend/App.BLL.Contracts/IProductService.cs
@@ -11,4 +11,9 @@ public interface IProductService : IBaseService<BLL.DTO.Product>
     /// Retrieves Products enriched with related data.
     /// </summary>
     Task<IEnumerable<BLL.DTO.Product?>> GetEnrichedProducts();
+    
+    /// <summary>
+    /// Retrieves all products provided by the specified supplier.
+    /// </summary>
+    Task<IEnumerable<BLL.DTO.Product?>> GetProductsBySupplierAsync(Guid supplierId);
 }

--- a/backend/App.BLL.DTO/Product.cs
+++ b/backend/App.BLL.DTO/Product.cs
@@ -55,6 +55,13 @@ public class Product : IDomainId
     public bool IsComponent { get; set; } = false;
     
     /// <summary>
+    /// Foreign key to the supplier who provides this product.
+    /// Navigation property to the related supplier.
+    /// </summary>
+    public Guid? SupplierId { get; set; }
+    public BLL.DTO.Supplier? Supplier { get; set; }
+    
+    /// <summary>
     /// Collection of actions (add/remove) associated with this product.
     /// </summary>
     public ICollection<BLL.DTO.ActionEntity>? Actions { get; set; }

--- a/backend/App.BLL.DTO/Supplier.cs
+++ b/backend/App.BLL.DTO/Supplier.cs
@@ -39,4 +39,9 @@ public class Supplier : IDomainId
     /// Collection of actions associated with this supplier (e.g., stock additions).
     /// </summary>
     public ICollection<BLL.DTO.ActionEntity>? Actions { get; set; }
+    
+    /// <summary>
+    /// Collection of products provided by this supplier.
+    /// </summary>
+    public ICollection<BLL.DTO.Product>? Products { get; set; }
 }

--- a/backend/App.BLL/Mappers/ProductBllMapper.cs
+++ b/backend/App.BLL/Mappers/ProductBllMapper.cs
@@ -33,6 +33,9 @@ public class ProductBllMapper : IMapper<BLL.DTO.Product, DAL.DTO.Product>
             
             IsComponent = entity.IsComponent,
             
+            SupplierId = entity.SupplierId,
+            Supplier = SupplierBllMapper.MapSimple(entity.Supplier),
+            
             Actions = entity.Actions?.Select(t => _actionEntityBllMapper.Map(t)).ToList()!,
         };
         return res;
@@ -60,6 +63,9 @@ public class ProductBllMapper : IMapper<BLL.DTO.Product, DAL.DTO.Product>
             
             IsComponent = entity.IsComponent,
             
+            SupplierId = entity.SupplierId,
+            Supplier = SupplierBllMapper.MapSimple(entity.Supplier),
+            
             Actions = entity.Actions?.Select(t => _actionEntityBllMapper.Map(t)).ToList()!,
         };
         return res;
@@ -83,6 +89,7 @@ public class ProductBllMapper : IMapper<BLL.DTO.Product, DAL.DTO.Product>
             Quantity = entity.Quantity,
             ProductCategoryId = entity.ProductCategoryId,
             IsComponent = entity.IsComponent,
+            SupplierId = entity.SupplierId,
         };
     }
     
@@ -104,6 +111,7 @@ public class ProductBllMapper : IMapper<BLL.DTO.Product, DAL.DTO.Product>
             Quantity = entity.Quantity,
             ProductCategoryId = entity.ProductCategoryId,
             IsComponent = entity.IsComponent,
+            SupplierId = entity.SupplierId,
         };
     }
 }

--- a/backend/App.BLL/Mappers/SupplierBllMapper.cs
+++ b/backend/App.BLL/Mappers/SupplierBllMapper.cs
@@ -11,6 +11,9 @@ public class SupplierBllMapper : IMapper<BLL.DTO.Supplier, DAL.DTO.Supplier>
     // Mapper used to map related Supplier objects
     private readonly ActionEntityBllMapper _actionEntityBllMapper = new();
     
+    // Mapper used to map related Supplier objects
+    private readonly ProductBllMapper _productBllMapper = new();
+    
     /// <summary>
     /// Maps a full BLL DTO Supplier entity to a DAL DTO Supplier entity, including related Addresses and Actions.
     /// </summary>
@@ -28,7 +31,9 @@ public class SupplierBllMapper : IMapper<BLL.DTO.Supplier, DAL.DTO.Supplier>
             AddressId = entity.AddressId,
             Address = AddressBllMapper.MapSimple(entity.Address),
             
-            Actions = entity.Actions?.Select(t => _actionEntityBllMapper.Map(t)).ToList()!
+            Actions = entity.Actions?.Select(t => _actionEntityBllMapper.Map(t)).ToList()!,
+            
+            Products = entity.Products?.Select(t => _productBllMapper.Map(t)).ToList()!
         };
         return res;
     }
@@ -50,7 +55,9 @@ public class SupplierBllMapper : IMapper<BLL.DTO.Supplier, DAL.DTO.Supplier>
             AddressId = entity.AddressId,
             Address = AddressBllMapper.MapSimple(entity.Address),
             
-            Actions = entity.Actions?.Select(t => _actionEntityBllMapper.Map(t)).ToList()!
+            Actions = entity.Actions?.Select(t => _actionEntityBllMapper.Map(t)).ToList()!,
+            
+            Products = entity.Products?.Select(t => _productBllMapper.Map(t)).ToList()!
         };
         return res;
     }

--- a/backend/App.BLL/Services/ProductService.cs
+++ b/backend/App.BLL/Services/ProductService.cs
@@ -26,4 +26,13 @@ public class ProductService : BaseService<BLL.DTO.Product, DAL.DTO.Product, IPro
         var res = await ServiceRepository.GetEnrichedProducts();
         return res.Select(u => _dalBllMapperProducts.Map(u));
     }
+    
+    /// <summary>
+    /// Returns specific supplier products.
+    /// </summary>
+    public async Task<IEnumerable<BLL.DTO.Product?>> GetProductsBySupplierAsync(Guid supplierId)
+    {
+        var res = await ServiceRepository.GetProductsBySupplierAsync(supplierId);
+        return res.Select(x => _dalBllMapperProducts.Map(x));
+    }
 }

--- a/backend/App.BLL/Utils/UnitConverter.cs
+++ b/backend/App.BLL/Utils/UnitConverter.cs
@@ -1,0 +1,35 @@
+namespace App.BLL.Utils;
+
+/// <summary>
+/// Utility class for converting between different measurement units.
+/// Supports mass (g, kg, mg) and volume (ml, l, cl), including approximate mass-volume conversions for water-like substances.
+/// </summary>
+public static class UnitConverter
+{
+    private static readonly Dictionary<(string from, string to), decimal> ConversionRates = new()
+    {
+        // Mass
+        { ("g", "kg"), 0.001m }, { ("kg", "g"), 1000m },
+        { ("g", "mg"), 1000m }, { ("mg", "g"), 0.001m },
+
+        // Volume
+        { ("ml", "l"), 0.001m }, { ("l", "ml"), 1000m },
+        { ("ml", "cl"), 0.1m }, { ("l", "cl"), 100m },
+
+        // Mass -> Volume (approximate for water-like substances)
+        { ("g", "ml"), 1m }, { ("g", "l"), 0.001m },
+        { ("kg", "ml"), 1000m }, { ("kg", "l"), 1m }
+    };
+
+    /// <summary>
+    /// Converts a value from one unit to another using predefined conversion rates.
+    /// </summary>
+    public static decimal Convert(decimal value, string from, string to)
+    {
+        if (from == to) return value;
+        if (ConversionRates.TryGetValue((from, to), out var rate))
+            return value * rate;
+
+        throw new Exception($"Unsupported conversion from {from} to {to}");
+    }
+}

--- a/backend/App.DAL.Contracts/IProductRepository.cs
+++ b/backend/App.DAL.Contracts/IProductRepository.cs
@@ -11,4 +11,9 @@ public interface IProductRepository: IBaseRepository<DAL.DTO.Product>
     /// Retrieves Products enriched with related data.
     /// </summary>
     Task<IEnumerable<DAL.DTO.Product?>> GetEnrichedProducts();
+    
+    /// <summary>
+    /// Retrieves all products associated with a given supplier ID.
+    /// </summary>
+    Task<IEnumerable<DAL.DTO.Product?>> GetProductsBySupplierAsync(Guid supplierId);
 }

--- a/backend/App.DAL.DTO/Product.cs
+++ b/backend/App.DAL.DTO/Product.cs
@@ -55,6 +55,13 @@ public class Product : IDomainId
     public bool IsComponent { get; set; } = false;
     
     /// <summary>
+    /// Foreign key to the supplier who provides this product.
+    /// Navigation property to the related supplier.
+    /// </summary>
+    public Guid? SupplierId { get; set; }
+    public DAL.DTO.Supplier? Supplier { get; set; }
+    
+    /// <summary>
     /// Collection of actions (add/remove) associated with this product.
     /// </summary>
     public ICollection<DAL.DTO.ActionEntity>? Actions { get; set; }

--- a/backend/App.DAL.DTO/Supplier.cs
+++ b/backend/App.DAL.DTO/Supplier.cs
@@ -39,4 +39,9 @@ public class Supplier : IDomainId
     /// Collection of actions associated with this supplier (e.g., stock additions).
     /// </summary>
     public ICollection<DAL.DTO.ActionEntity>? Actions { get; set; }
+    
+    /// <summary>
+    /// Collection of products provided by this supplier.
+    /// </summary>
+    public ICollection<DAL.DTO.Product>? Products { get; set; }
 }

--- a/backend/App.DAL.EF/Mappers/ProductUowMapper.cs
+++ b/backend/App.DAL.EF/Mappers/ProductUowMapper.cs
@@ -33,6 +33,9 @@ public class ProductUowMapper: IMapper<DAL.DTO.Product, Domain.Logic.Product>
             
             IsComponent = entity.IsComponent,
             
+            SupplierId = entity.SupplierId,
+            Supplier = SupplierUowMapper.MapSimple(entity.Supplier),
+            
             Actions = entity.Actions?.Select(t => _actionEntityUowMapper.Map(t)).ToList()!,
         };
         return res;
@@ -60,6 +63,9 @@ public class ProductUowMapper: IMapper<DAL.DTO.Product, Domain.Logic.Product>
             
             IsComponent = entity.IsComponent,
             
+            SupplierId = entity.SupplierId,
+            Supplier = SupplierUowMapper.MapSimple(entity.Supplier),
+            
             Actions = entity.Actions?.Select(t => _actionEntityUowMapper.Map(t)).ToList()!,
         };
         return res;
@@ -83,6 +89,7 @@ public class ProductUowMapper: IMapper<DAL.DTO.Product, Domain.Logic.Product>
             Quantity = entity.Quantity,
             ProductCategoryId = entity.ProductCategoryId,
             IsComponent = entity.IsComponent,
+            SupplierId = entity.SupplierId,
         };
     }
 
@@ -104,6 +111,7 @@ public class ProductUowMapper: IMapper<DAL.DTO.Product, Domain.Logic.Product>
             Quantity = entity.Quantity,
             ProductCategoryId = entity.ProductCategoryId,
             IsComponent = entity.IsComponent,
+            SupplierId = entity.SupplierId,
         };
     }
 }

--- a/backend/App.DAL.EF/Mappers/SupplierUowMapper.cs
+++ b/backend/App.DAL.EF/Mappers/SupplierUowMapper.cs
@@ -11,6 +11,9 @@ public class SupplierUowMapper: IMapper<DAL.DTO.Supplier, Domain.Logic.Supplier>
     // Mapper used to map related Supplier objects
     private readonly ActionEntityUowMapper _actionEntityUowMapper = new();
     
+    // Mapper used to map related Supplier objects
+    private readonly ProductUowMapper _productUowMapper = new();
+    
     /// <summary>
     /// Maps a full Domain Supplier entity to a DAL DTO Supplier entity, including related Addresses and Actions.
     /// </summary>
@@ -28,7 +31,9 @@ public class SupplierUowMapper: IMapper<DAL.DTO.Supplier, Domain.Logic.Supplier>
             AddressId = entity.AddressId,
             Address = AddressUowMapper.MapSimple(entity.Address),
             
-            Actions = entity.Actions?.Select(t => _actionEntityUowMapper.Map(t)).ToList()!
+            Actions = entity.Actions?.Select(t => _actionEntityUowMapper.Map(t)).ToList()!,
+            
+            Products = entity.Products?.Select(t => _productUowMapper.Map(t)).ToList()!
         };
         return res;
     }
@@ -50,7 +55,9 @@ public class SupplierUowMapper: IMapper<DAL.DTO.Supplier, Domain.Logic.Supplier>
             AddressId = entity.AddressId,
             Address = AddressUowMapper.MapSimple(entity.Address),
             
-            Actions = entity.Actions?.Select(t => _actionEntityUowMapper.Map(t)).ToList()!
+            Actions = entity.Actions?.Select(t => _actionEntityUowMapper.Map(t)).ToList()!,
+            
+            Products = entity.Products?.Select(t => _productUowMapper.Map(t)).ToList()!
         };
         return res;
     }

--- a/backend/App.DAL.EF/Repositories/ProductRepository.cs
+++ b/backend/App.DAL.EF/Repositories/ProductRepository.cs
@@ -26,4 +26,17 @@ public class ProductRepository: BaseRepository<DAL.DTO.Product, Domain.Logic.Pro
 
         return domainEntities.Select(e => Mapper.Map(e));
     }
+    
+    /// <summary>
+    /// Retrieves all products with their associated supplier.
+    /// </summary>
+    public async Task<IEnumerable<DAL.DTO.Product?>> GetProductsBySupplierAsync(Guid supplierId)
+    {
+        var domainEntities = await RepositoryDbSet
+            .Where(p => p.SupplierId == supplierId)
+            .Include(p => p.ProductCategory)
+            .ToListAsync();
+
+        return domainEntities.Select(p => Mapper.Map(p));
+    }
 }

--- a/backend/App.DTO/v1/ApiEntities/EnrichedProduct.cs
+++ b/backend/App.DTO/v1/ApiEntities/EnrichedProduct.cs
@@ -51,6 +51,14 @@ public class EnrichedProduct : IDomainId
     public string ProductCategoryName { get; set; } = default!;
     
     /// <summary>
+    /// Foreign key for Supplier.
+    /// Name of the product category.
+    /// </summary>
+    public Guid? SupplierId { get; set; }
+    public string SupplierName { get; set; } = default!;
+    public string SupplierEmail { get; set; } = default!;
+    
+    /// <summary>
     /// Indicates if the product is a component in a recipe.
     /// </summary>
     public bool IsComponent { get; set; } = false;

--- a/backend/App.DTO/v1/ApiMapper/EnrichedProductApiMapper.cs
+++ b/backend/App.DTO/v1/ApiMapper/EnrichedProductApiMapper.cs
@@ -27,6 +27,9 @@ public class EnrichedProductApiMapper : IMapper<EnrichedProduct, BLL.DTO.Product
             Quantity = entity.Quantity,
             ProductCategoryId = entity.ProductCategoryId,
             ProductCategoryName = entity.ProductCategory?.Name ?? "Unknown",
+            SupplierId = entity.SupplierId,
+            SupplierName = entity.Supplier?.Name ?? "Unknown",
+            SupplierEmail = entity.Supplier?.Email ?? "Unknown",
         };
     }
 

--- a/backend/App.DTO/v1/Mappers/ProductApiMapper.cs
+++ b/backend/App.DTO/v1/Mappers/ProductApiMapper.cs
@@ -25,6 +25,7 @@ public class ProductApiMapper : IMapper<Product, BLL.DTO.Product>
             Quantity = entity.Quantity,
             ProductCategoryId = entity.ProductCategoryId,
             IsComponent = entity.IsComponent,
+            SupplierId = entity.SupplierId,
         };
         return res;
     }
@@ -46,6 +47,7 @@ public class ProductApiMapper : IMapper<Product, BLL.DTO.Product>
             Quantity = entity.Quantity,
             ProductCategoryId = entity.ProductCategoryId,
             IsComponent = entity.IsComponent,
+            SupplierId = entity.SupplierId,
         };
         return res;
     }
@@ -66,6 +68,7 @@ public class ProductApiMapper : IMapper<Product, BLL.DTO.Product>
             Quantity = entity.Quantity,
             ProductCategoryId = entity.ProductCategoryId,
             IsComponent = entity.IsComponent,
+            SupplierId = entity.SupplierId,
         };
         return res;
     }

--- a/backend/App.DTO/v1/Product.cs
+++ b/backend/App.DTO/v1/Product.cs
@@ -51,4 +51,9 @@ public class Product : IDomainId
     /// Indicates if the product is a component in a recipe.
     /// </summary>
     public bool IsComponent { get; set; } = false;
+    
+    /// <summary>
+    /// Foreign key to the supplier who provides this product.
+    /// </summary>
+    public Guid? SupplierId { get; set; }
 }

--- a/backend/App.DTO/v1/ProductCreate.cs
+++ b/backend/App.DTO/v1/ProductCreate.cs
@@ -42,4 +42,9 @@ public class ProductCreate
     /// Indicates if the product is a component in a recipe.
     /// </summary>
     public bool IsComponent { get; set; } = false;
+    
+    /// <summary>
+    /// Foreign key to the supplier who provides this product.
+    /// </summary>
+    public Guid? SupplierId { get; set; }
 }

--- a/backend/App.Domain/Logic/Product.cs
+++ b/backend/App.Domain/Logic/Product.cs
@@ -50,6 +50,13 @@ public class Product : BaseEntity
     public bool IsComponent { get; set; } = false;
     
     /// <summary>
+    /// Foreign key to the supplier who provides this product.
+    /// Navigation property to the related supplier.
+    /// </summary>
+    public Guid? SupplierId { get; set; }
+    public Domain.Logic.Supplier? Supplier { get; set; }
+    
+    /// <summary>
     /// Collection of actions (add/remove) associated with this product.
     /// </summary>
     public ICollection<Domain.Logic.ActionEntity>? Actions { get; set; }

--- a/backend/App.Domain/Logic/Supplier.cs
+++ b/backend/App.Domain/Logic/Supplier.cs
@@ -34,4 +34,9 @@ public class Supplier : BaseEntity
     /// Collection of actions associated with this supplier (e.g., stock additions).
     /// </summary>
     public ICollection<Domain.Logic.ActionEntity>? Actions { get; set; }
+    
+    /// <summary>
+    /// Collection of products provided by this supplier.
+    /// </summary>
+    public ICollection<Domain.Logic.Product>? Products { get; set; }
 }

--- a/backend/WebApp/ApiControllers/ProductsController.cs
+++ b/backend/WebApp/ApiControllers/ProductsController.cs
@@ -134,5 +134,23 @@ namespace WebApp.ApiControllers
             _logger.LogInformation("Returned {Count} enriched products", res.Count);
             return Ok(res);
         }
+        
+        /// <summary>
+        /// Get products by supplier.
+        /// </summary>
+        [HttpGet("by-supplier/{supplierId}")]
+        [ProducesResponseType(typeof(IEnumerable<Product>), StatusCodes.Status200OK)]
+        public async Task<ActionResult<IEnumerable<Product>>> GetProductsBySupplier(Guid supplierId)
+        {
+            _logger.LogInformation("Fetching products for supplier ID {SupplierId}", supplierId);
+
+            var products = await _bll.ProductService.GetProductsBySupplierAsync(supplierId);
+
+            var result = products.Select(p => _mapper.Map(p)!).ToList();
+
+            _logger.LogInformation("Returned {Count} products for supplier ID {SupplierId}", result.Count, supplierId);
+
+            return Ok(result);
+        }
     }
 }

--- a/backend/WebApp/ApiControllers/SuppliersController.cs
+++ b/backend/WebApp/ApiControllers/SuppliersController.cs
@@ -134,5 +134,26 @@ namespace WebApp.ApiControllers
             _logger.LogInformation("Returned {Count} enriched suppliers", res.Count);
             return Ok(res);
         }
+        
+        /// <summary>
+        /// Get all products offered by the specified supplier.
+        /// </summary>
+        [HttpGet("{id}/products")]
+        [ProducesResponseType(typeof(IEnumerable<Product>), StatusCodes.Status200OK)]
+        public async Task<ActionResult<IEnumerable<Product>>> GetProductsBySupplier(Guid id)
+        {
+            _logger.LogInformation("Fetching products for supplier ID {Id}", id);
+    
+            var products = await _bll.ProductService.GetProductsBySupplierAsync(id);
+    
+            if (!products.Any())
+            {
+                _logger.LogInformation("No products found for supplier ID {Id}", id);
+                return Ok(new List<Product>());
+            }
+
+            var result = products.Select(p => new ProductApiMapper().Map(p)!);
+            return Ok(result);
+        }
     }
 }

--- a/backend/WebApp/Controllers/ProductsController.cs
+++ b/backend/WebApp/Controllers/ProductsController.cs
@@ -68,6 +68,11 @@ namespace WebApp.Controllers
                     nameof(ProductCategory.Id),
                     nameof(ProductCategory.Name)
                 ),
+                
+                SupplierSelectList = new SelectList(await _bll.SupplierService.AllAsync(User.GetUserId()),
+                    nameof(Supplier.Id),
+                    nameof(Supplier.Name)
+                ),
             };
             
             return View(vm);
@@ -91,6 +96,8 @@ namespace WebApp.Controllers
             _logger.LogWarning("Invalid model state on product creation");
             vm.ProductCategorySelectList = new SelectList(await _bll.ProductCategoryService.AllAsync(User.GetUserId()),
                 nameof(ProductCategory.Id), nameof(ProductCategory.Name), vm.Product.ProductCategoryId);
+            vm.SupplierSelectList = new SelectList(await _bll.SupplierService.AllAsync(User.GetUserId()),
+                nameof(Supplier.Id), nameof(Supplier.Name), vm.Product.SupplierId);
 
             return View(vm);
         }
@@ -118,6 +125,12 @@ namespace WebApp.Controllers
                 ProductCategorySelectList = new SelectList(await _bll.ProductCategoryService.AllAsync(User.GetUserId()),
                     nameof(ProductCategory.Id),
                     nameof(ProductCategory.Name),
+                    product.ProductCategoryId
+                ),
+                
+                SupplierSelectList = new SelectList(await _bll.SupplierService.AllAsync(User.GetUserId()),
+                    nameof(Supplier.Id),
+                    nameof(Supplier.Name),
                     product.ProductCategoryId
                 ),
                 Product = product
@@ -149,6 +162,8 @@ namespace WebApp.Controllers
             _logger.LogWarning("Invalid model state while editing product {Id}", id);
             vm.ProductCategorySelectList = new SelectList(await _bll.ProductCategoryService.AllAsync(User.GetUserId()),
                 nameof(ProductCategory.Id), nameof(ProductCategory.Name), vm.Product.ProductCategory);
+            vm.SupplierSelectList = new SelectList(await _bll.ProductCategoryService.AllAsync(User.GetUserId()),
+                nameof(Supplier.Id), nameof(Supplier.Name), vm.Product.Supplier);
 
             return View(vm);
         }

--- a/backend/WebApp/ViewModels/ProductCreateEditViewModel.cs
+++ b/backend/WebApp/ViewModels/ProductCreateEditViewModel.cs
@@ -20,4 +20,10 @@ public class ProductCreateEditViewModel
     /// </summary>
     [ValidateNever]
     public SelectList ProductCategorySelectList { get; set; } = default!;
+    
+    /// <summary>
+    /// A select list of suppliers used to populate the category dropdown in the form.
+    /// </summary>
+    [ValidateNever]
+    public SelectList SupplierSelectList { get; set; } = default!;
 }

--- a/backend/WebApp/Views/Products/Create.cshtml
+++ b/backend/WebApp/Views/Products/Create.cshtml
@@ -52,6 +52,10 @@
                 <span asp-validation-for="Product.IsComponent" class="text-danger"></span>
             </div>
             <div class="form-group">
+                <label asp-for="Product.SupplierId" class="control-label"></label>
+                <select asp-for="Product.SupplierId" class ="form-control" asp-items="Model.SupplierSelectList"></select>
+            </div>
+            <div class="form-group">
                 <input type="submit" value="Create" class="btn btn-primary" />
             </div>
         </form>

--- a/backend/WebApp/Views/Products/Delete.cshtml
+++ b/backend/WebApp/Views/Products/Delete.cshtml
@@ -59,6 +59,12 @@
         <dd class="col-sm-10">
             @Html.DisplayFor(model => model.IsComponent)
         </dd>
+        <dt class = "col-sm-2">
+            @Html.DisplayNameFor(model => model.Supplier)
+        </dt>
+        <dd class = "col-sm-10">
+            @Html.DisplayFor(model => model.Supplier!.Name)
+        </dd>
     </dl>
 
     <form asp-action="Delete">

--- a/backend/WebApp/Views/Products/Details.cshtml
+++ b/backend/WebApp/Views/Products/Details.cshtml
@@ -58,6 +58,12 @@
         <dd class="col-sm-10">
             @Html.DisplayFor(model => model.IsComponent)
         </dd>
+        <dt class = "col-sm-2">
+            @Html.DisplayNameFor(model => model.Supplier)
+        </dt>
+        <dd class = "col-sm-10">
+            @Html.DisplayFor(model => model.Supplier!.Name)
+        </dd>
     </dl>
 </div>
 <div>

--- a/backend/WebApp/Views/Products/Edit.cshtml
+++ b/backend/WebApp/Views/Products/Edit.cshtml
@@ -52,6 +52,11 @@
                 <label asp-for="Product.IsComponent" class="form-check-label"></label>
                 <span asp-validation-for="Product.IsComponent" class="text-danger"></span>
             </div>
+            <div class="form-group">
+                <label asp-for="Product.SupplierId" class="control-label"></label>
+                <select asp-for="Product.SupplierId" class="form-control" asp-items="Model.SupplierSelectList"></select>
+                <span asp-validation-for="Product.SupplierId" class="text-danger"></span>
+            </div>
             <input type="hidden" asp-for="Product.Id" />
             <div class="form-group">
                 <input type="submit" value="Save" class="btn btn-primary" />

--- a/backend/WebApp/Views/Products/Index.cshtml
+++ b/backend/WebApp/Views/Products/Index.cshtml
@@ -36,6 +36,9 @@
         <th>
             @Html.DisplayNameFor(model => model.IsComponent)
         </th>
+        <th>
+            @Html.DisplayNameFor(model => model.Supplier)
+        </th>
         <th></th>
     </tr>
     </thead>
@@ -65,6 +68,9 @@
             </td>
             <td>
                 @Html.DisplayFor(modelItem => item.IsComponent)
+            </td>
+            <td>
+                @Html.DisplayFor(modelItem => item.SupplierId)
             </td>
             <td>
                 <a asp-action="Edit" asp-route-id="@item.Id">Edit</a> |

--- a/frontend/src/domain/logic/IProduct.ts
+++ b/frontend/src/domain/logic/IProduct.ts
@@ -8,5 +8,6 @@ export interface IProduct extends IDomainId {
   price: number;
   quantity: number;
   productCategoryId: string;
+  supplierId: string;
   isComponent: boolean;
 }

--- a/frontend/src/domain/logic/IProductEnriched.ts
+++ b/frontend/src/domain/logic/IProductEnriched.ts
@@ -10,4 +10,8 @@ export interface IProductEnriched extends IDomainId {
   quantity: number;
   productCategoryId: string;
   productCategoryName: string;
+  supplierId: string;
+  supplierName: string;
+  supplierEmail: string;
+  isComponent: boolean;
 }

--- a/frontend/src/navigation/Header.vue
+++ b/frontend/src/navigation/Header.vue
@@ -13,6 +13,7 @@ const fullName = computed(() => userStore.firstName ?? "Kasutaja");
 const logout = () => {
   userStore.jwt = null;
   userStore.refreshToken = null;
+  userStore.roles = [];
   router.push("/");
 };
 

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -12,9 +12,6 @@ import Suppliers from "@/views/SupplierView/Suppliers.vue";
 import CreateSupplier from "@/views/SupplierView/CreateSupplier.vue";
 import EditSupplier from "@/views/SupplierView/EditSupplier.vue";
 import StorageRooms from "@/views/InventoryView/StorageRooms.vue";
-import CurrentStock from "@/views/InventoryView/CurrentStock.vue";
-import EditCurrentstock from "@/views/InventoryView/EditCurrentstock.vue";
-import CreateCurrentStock from "@/views/InventoryView/CreateCurrentStock.vue";
 import UserDetailsView from "@/views/AccountView/UserDetailsView.vue";
 import { useUserDataStore } from "@/stores/userDataStore";
 import RegisterAccount from "@/views/AccountView/RegisterAccount.vue";
@@ -23,7 +20,6 @@ import AssignRoleToUserPage from "@/views/AccountView/AssignRoleToUserPage.vue";
 import CreateRolePage from "@/views/AccountView/CreateRolePage.vue";
 import UserListWithRoles from "@/views/AccountView/UserListWithRoles.vue";
 import Home from "@/views/Home.vue";
-import {User} from "lucide-vue-next";
 import MonthlyStatistics from "@/views/InventoryView/MonthlyStatistics.vue";
 
 const routes = [
@@ -41,10 +37,7 @@ const routes = [
   { path: "/createsupplier", name: "CreateSupplier", component: CreateSupplier },
   { path: "/editsupplier/:id", name: "EditSupplier", component: EditSupplier },
   { path: "/storagerooms", name: "StorageRooms", component: StorageRooms },
-  { path: "/currentstock/:storageRoomId", name: "CurrentStock", component: CurrentStock },
   { path: "/monthlyStatistics/:storageRoomId", name: "MonthlyStatistics", component: MonthlyStatistics },
-  { path: "/editcurrentstock/:id", name: "EditCurrentStock", component: EditCurrentstock },
-  { path: "/createcurrentStock", name: "CreateCurrentStock", component: CreateCurrentStock },
   { path: "/users/:id", name: "UserDetails", component: UserDetailsView },
   { path: "/register", name: "Register", component: RegisterAccount },
   { path: "/getRole", name: "getRole", component: GetRolesPage },
@@ -72,10 +65,7 @@ router.beforeEach((to, from, next) => {
     "/createsupplier",
     "/editsupplier/:id",
     "/storagerooms",
-    "/currentstock/:storageRoomId",
     "/monthlyStatistics/:storageRoomId",
-    "/editcurrentstock/:id",
-    "/createcurrentStock",
     "/users/:id",
     "/register",
     "/createRole",

--- a/frontend/src/services/mvcServices/MonthlyStatisticsService.ts
+++ b/frontend/src/services/mvcServices/MonthlyStatisticsService.ts
@@ -13,7 +13,7 @@ export class MonthlyStatisticsService extends BaseEntityService<IMonthlyStatisti
 
   async getByStorageRoomId(id: string): Promise<IResultObject<IMonthlyStatisticsEnriched[]>> {
     const response = await this.axiosInstance.get(`/monthlyStatistics/bystorageroom/${id}`);
-    return { data: response.data };
+    return { data: response.data as IMonthlyStatisticsEnriched[] };
   }
 
   async getEnrichedMonthlyStatistics(): Promise<IResultObject<IMonthlyStatisticsEnriched[]>> {
@@ -22,5 +22,12 @@ export class MonthlyStatisticsService extends BaseEntityService<IMonthlyStatisti
       data: response.data as IMonthlyStatisticsEnriched[],
       errors: [],
     };
+  }
+
+  async getConvertedQuantity(id: string, targetUnit: string): Promise<string> {
+    const response = await this.axiosInstance.get(`/monthlyStatistics/converted/${id}`, {
+      params: { targetUnit }
+    });
+    return response.data as string;
   }
 }

--- a/frontend/src/services/mvcServices/ProductServices.ts
+++ b/frontend/src/services/mvcServices/ProductServices.ts
@@ -16,4 +16,12 @@ export class ProductService extends BaseEntityService<IProduct> {
       errors: [],
     };
   }
+
+  async getBySupplier(supplierId: string): Promise<IResultObject<IProduct[]>> {
+    const response = await this.axiosInstance.get(`/products/by-supplier/${supplierId}`);
+    return {
+      data: response.data as IProduct[],
+      errors: [],
+    };
+  }
 }

--- a/frontend/src/views/AccountView/Login.vue
+++ b/frontend/src/views/AccountView/Login.vue
@@ -23,7 +23,7 @@ const doLogin = async () => {
     store.lastName = response.data.lastName;
     store.email = response.data.email;
     store.username = response.data.username;
-    store.role = response.data.roles?.[0] ?? null;
+    store.roles = response.data.roles ?? [];
 
     router.push({ name: 'Home' });
   } else {


### PR DESCRIPTION
…statistics

Created bidirectional relationship between Products and Suppliers → Products can now be filtered by Supplier
→ Supplier detail view now displays all associated Products Implemented unit conversion support on MonthlyStatistics page → Added dropdown to convert removed quantity into desired units → Handles both single products and recipe components correctly Backend now converts units when writing off recipe components → Ensures accurate MonthlyStatistics in mixed unit scenarios (e.g. popcorn in g, oil in l) Next steps:

Improve UX of the product write-off form
→ Show unit indicators (e.g. "Popcorn - in grams", "Saku Originaal - pieces") → Display product size info when items are in pieces → Make the form more intuitive and visually refined → Revisit conversion logic for edge cases or uncommon units